### PR TITLE
incluido-view-model-register-output-swagger

### DIFF
--- a/WebApplicationApi/Controllers/CoursesController.cs
+++ b/WebApplicationApi/Controllers/CoursesController.cs
@@ -26,7 +26,7 @@ namespace WebApplicationApi.Controllers
     /// </summary>
     /// <param name="coursesViewModelInput"></param>
     /// <returns>Retorna status 201 e dados do curso do usuário</returns>
-    [SwaggerResponse(StatusCodes.Status201Created, "Curso cadastrado com sucesso", typeof(CoursesViewModelInput))]
+    [SwaggerResponse(StatusCodes.Status201Created, "Curso cadastrado com sucesso", typeof(CoursesViewModelOutput))]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Campos obrigatórios", typeof(ValidationFieldViewModelOutput))]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Erro interno", typeof(GenericErrorViewModel))]
     [HttpPost]


### PR DESCRIPTION
Foi alterado a view model de saída para registro de curso que antes era a RegisterViewModelInput e passou a ser a RegisterViewModelOutput na documentação do swagger.